### PR TITLE
Refactor getName with dynamic model and fallback

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -287,7 +287,7 @@ export default function Home() {
   function getName(input: string) {
     const nameOllama = new ChatOllama({
       baseUrl: "http://localhost:11434",
-      model: "llama2",
+      model: activeModel && activeModel.trim() !== "" ? activeModel : "llama2",
       verbose: false,
     });
     return nameOllama!


### PR DESCRIPTION
This PR refactors the `getName` function to utilize the dynamically selected model stored in `activeModel`. The function was previously hardcoded to use `llama2`, limiting flexibility. Now, it will fall back to `llama2` only if `activeModel` is not set or is empty, enhancing the function's adaptability and allowing it to respect the user's model choice.
